### PR TITLE
[ch33079] Fixed the route parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/mitchell/lambdarouter
 
+go 1.14
+
 require (
 	github.com/aws/aws-lambda-go v1.10.0
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/router.go
+++ b/router.go
@@ -81,7 +81,9 @@ func (r Router) Invoke(ctx context.Context, payload []byte) ([]byte, error) {
 	path := req.Path
 
 	for param, value := range req.PathParameters {
-		path = strings.Replace(path, value, "{"+param+"}", -1)
+		oldValue := fmt.Sprintf("/%s/", value)
+		newValue := fmt.Sprintf("/{%s}/", param)
+		path = strings.Replace(path, oldValue, newValue, -1)
 	}
 
 	i, found := r.events.Get([]byte(req.HTTPMethod + path))

--- a/router_test.go
+++ b/router_test.go
@@ -51,6 +51,7 @@ func TestRouter(t *testing.T) {
 		desc(t, 4, "insert routes with the specified prefix succesfully")
 		r.Group("/ding", func(r *Router) {
 			r.Post("dong/{door}", handler)
+			r.Post("{dong}/door", handler)
 		})
 	}
 
@@ -89,6 +90,20 @@ func TestRouter(t *testing.T) {
 		_, err = r.Invoke(ctx, nil)
 
 		a.Error(err)
+
+		e = events.APIGatewayProxyRequest{
+			Path:           "/prefix/ding/talal/door",
+			HTTPMethod:     http.MethodPost,
+			PathParameters: map[string]string{"dong": "talal"},
+		}
+
+		desc(t, 4, "should succesfully route and invoke a defined route")
+		ejson, _ = json.Marshal(e)
+
+		res, err = r.Invoke(ctx, ejson)
+
+		a.NoError(err)
+		a.Exactly("null", string(res))
 	}
 
 }


### PR DESCRIPTION
https://app.clubhouse.io/tvtime/story/33079/fix-the-season-watch-unwatch-endpoint

By not considering the `/`, the replacement could randomly replace the params.
For example, `/v1/tracking/d7717d88-7a82-404c-a02a-120164b2b925/season/1/watch` would become `/v{seasonNumber}/tracking/b3d8{seasonNumber}bca-20af-422f-98f7-ed02c{seasonNumber}a8ec26/season/{seasonNumber}/watch` because all `1` were replaced by `{seasonNumber}`